### PR TITLE
Catch exceptions and emit an error on the stream

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -124,7 +124,11 @@ function write (chunk, encoding, fn) {
   // XXX: old Writable stream API compat... remove at some point...
   if ('function' == typeof encoding) fn = encoding;
 
-  data(this, chunk, null, fn);
+  try{
+    data(this, chunk, null, fn);
+  }catch(err){
+    this.emit('error', new Error(err.message));
+  }
 }
 
 /**
@@ -143,7 +147,11 @@ function transform (chunk, output, fn) {
     output = this._parserOutput;
   }
 
-  data(this, chunk, output, fn);
+  try{
+    data(this, chunk, output, fn);
+  }catch(err){
+    this.emit('error', new Error(err.message));
+  }
 }
 
 /**


### PR DESCRIPTION
I found that when using github.com/TooTallNate/node-wav, sometimes uncatchable errors were being thrown from node-stream-parser. (When trying to parse an incompatible file as wav)

This patch allows errors to be caught as stream "error" events.
